### PR TITLE
Update dependencies and reduce AWS-SDK dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,42 +8,42 @@
     <artifactId>jobworker</artifactId>
     <version>1.0</version>
 
+    <properties>
+        <aws-sdk-version>1.11.809</aws-sdk-version>
+        <log4j-version>2.13.3</log4j-version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.43</version>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-codepipeline</artifactId>
-            <version>1.11.43</version>
+            <version>${aws-sdk-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.13.3</version>
+            <version>${log4j-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.3</version>
+            <version>${log4j-version}</version>
         </dependency>
         <dependency>
             <groupId>commons-daemon</groupId>
             <artifactId>commons-daemon</artifactId>
-            <version>1.0.15</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The only AWS API this package uses is CodePipleine's, there's no reason
to include other services' SDKs.
